### PR TITLE
Make sighash optional

### DIFF
--- a/zcash_proofs/src/sapling/verifier.rs
+++ b/zcash_proofs/src/sapling/verifier.rs
@@ -40,10 +40,10 @@ impl SaplingVerificationContextInner {
         nullifier: &[u8; 32],
         rk: &PublicKey,
         sighash_value: &[u8; 32],
-        spend_auth_sig: &Signature,
+        spend_auth_sig: &Option<Signature>,
         zkproof: Proof<Bls12>,
         verifier_ctx: &mut C,
-        spend_auth_sig_verifier: impl FnOnce(&mut C, &PublicKey, [u8; 64], &Signature) -> bool,
+        spend_auth_sig_verifier: impl FnOnce(&mut C, &PublicKey, [u8; 64], &Option<Signature>) -> bool,
         proof_verifier: impl FnOnce(&mut C, Proof<Bls12>, [bls12_381::Scalar; 7]) -> bool,
     ) -> bool {
         // The "cv is not small order" happens when a SpendDescription is deserialized.

--- a/zcash_proofs/src/sapling/verifier/batch.rs
+++ b/zcash_proofs/src/sapling/verifier/batch.rs
@@ -62,7 +62,7 @@ impl BatchValidator {
                 &spend.nullifier().0,
                 spend.rk(),
                 &sighash,
-                spend.spend_auth_sig(),
+                &Some(*spend.spend_auth_sig()),
                 zkproof,
                 self,
                 |this, rk, _, spend_auth_sig| {
@@ -71,7 +71,9 @@ impl BatchValidator {
                     );
                     let spend_auth_sig = {
                         let mut buf = [0; 64];
-                        spend_auth_sig.write(&mut buf[..]).unwrap();
+			if let Some(spend_auth_sig) = spend_auth_sig {
+                            spend_auth_sig.write(&mut buf[..]).unwrap();
+			}
                         redjubjub::Signature::<redjubjub::SpendAuth>::from(buf)
                     };
 

--- a/zcash_proofs/src/sapling/verifier/single.rs
+++ b/zcash_proofs/src/sapling/verifier/single.rs
@@ -37,7 +37,7 @@ impl SaplingVerificationContext {
         nullifier: &[u8; 32],
         rk: PublicKey,
         sighash_value: &[u8; 32],
-        spend_auth_sig: Signature,
+        spend_auth_sig: Option<Signature>,
         zkproof: Proof<Bls12>,
         verifying_key: &PreparedVerifyingKey<Bls12>,
     ) -> bool {
@@ -52,7 +52,11 @@ impl SaplingVerificationContext {
             zkproof,
             &mut (),
             |_, rk, msg, spend_auth_sig| {
-                rk.verify_with_zip216(&msg, spend_auth_sig, SPENDING_KEY_GENERATOR, zip216_enabled)
+		if let Some(spend_auth_sig) = spend_auth_sig {
+		    rk.verify_with_zip216(&msg, spend_auth_sig, SPENDING_KEY_GENERATOR, zip216_enabled)
+		} else {
+		    true
+		}
             },
             |_, proof, public_inputs| {
                 verify_proof(verifying_key, &proof, &public_inputs[..]).is_ok()


### PR DESCRIPTION
Makes sighash optional. Only code validating shield stake proof should pass None to the validation.
